### PR TITLE
docs: Fix a few typos

### DIFF
--- a/python/keepass/__init__.py
+++ b/python/keepass/__init__.py
@@ -10,5 +10,5 @@ KeePass module
 # Free Software Foundation; either version 2, or (at your option) any
 # later version.
 
-# ... even thoough this file is essentially empty....
+# ... even though this file is essentially empty....
 

--- a/python/keepass/cli.py
+++ b/python/keepass/cli.py
@@ -142,7 +142,7 @@ class Cli(object):
         'Read a file to the in-memory database'
         opts,files = self.ops['open'].parse_args(opts)
         import kpdb
-        # fixme - add support for openning/merging multiple DBs!
+        # fixme - add support for opening/merging multiple DBs!
         try:
             dbfile = files[0]
         except IndexError:

--- a/python/keepass/hier.py
+++ b/python/keepass/hier.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 '''
-Classes to construct a hiearchy holding infoblocks.
+Classes to construct a hierarchy holding infoblocks.
 '''
 
 # This file is part of python-keepass and is Copyright (C) 2012 Brett Viren.
@@ -115,7 +115,7 @@ class CollectVisitor(Visitor):
     '''
     A callable visitor that will collect the groups and entries into
     flat lists.  After the descent the results are available in the
-    .groups and .entries data memebers.
+    .groups and .entries data members.
     '''
     def __init__(self):
         self.groups = []
@@ -140,19 +140,19 @@ class PathVisitor(Visitor):
 
     The path is a list of group names with the last element being
     either a group name or an entry title.  The path can be a list
-    object or a string interpreted to be delimited by slashs (think
+    object or a string interpreted to be delimited by slashes (think
     UNIX pathspec).
 
     If stop_on_first is False, the visitor will not abort after the
     first match but will instead keep collecting all matches.  This
     can be used to collect groups or entries that are degenerate in
     their group_name or title, respectively.  After the descent the
-    collected values can be retrived from PathVisitor.results()
+    collected values can be retrieved from PathVisitor.results()
 
     This visitor also maintains a best match.  In the event of failure
     (return of None) the .best_match data member will hold the group
     object that was located where the path diverged from what was
-    found.  The .path data memeber will retain the remain part of the
+    found.  The .path data member will retain the remain part of the
     unmatched path.
     '''
     def __init__(self,path,stop_on_first = True):
@@ -200,7 +200,7 @@ class PathVisitor(Visitor):
 
 class Node(object):
     '''
-    A node in the group hiearchy.  
+    A node in the group hierarchy.  
 
     This basically associates entries to their group
 

--- a/python/keepass/infoblock.py
+++ b/python/keepass/infoblock.py
@@ -110,7 +110,7 @@ class InfoBase(object):
         return length
 
     def encode(self):
-        'Return binary string representatoin'
+        'Return binary string representation'
         string = ""
         for typ,siz in self.order:
             if typ == 0xFFFF:   # end of block

--- a/python/keepass/kpdb.py
+++ b/python/keepass/kpdb.py
@@ -82,7 +82,7 @@ class Database(object):
         return
 
     def final_key(self,masterkey,masterseed,masterseed2,rounds):
-        '''Munge masterkey into the final key for decryping payload by
+        '''Munge masterkey into the final key for decrypting payload by
         encrypting it for the given number of rounds masterseed2 and
         hashing it with masterseed.'''
         from Crypto.Cipher import AES


### PR DESCRIPTION
There are small typos in:
- python/keepass/__init__.py
- python/keepass/cli.py
- python/keepass/hier.py
- python/keepass/infoblock.py
- python/keepass/kpdb.py

Fixes:
- Should read `hierarchy` rather than `hiearchy`.
- Should read `though` rather than `thoough`.
- Should read `slashes` rather than `slashs`.
- Should read `retrieved` rather than `retrived`.
- Should read `representation` rather than `representatoin`.
- Should read `opening` rather than `openning`.
- Should read `members` rather than `memebers`.
- Should read `member` rather than `memeber`.
- Should read `decrypting` rather than `decryping`.



Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md